### PR TITLE
Add form to delete orphaned entities

### DIFF
--- a/includes/tripal_alchemist.api.inc
+++ b/includes/tripal_alchemist.api.inc
@@ -522,7 +522,6 @@ function tripal_alchemist_delete_orphaned_entities($bundle_id) {
                           LEFT JOIN chado.' . $chado_table . ' CT ON BT.record_id = CT.' . $primary_key . '
                           WHERE CT.' . $primary_key . ' IS NULL ORDER BY entity_id desc
                           LIMIT :limit', [
-      ':offset' => $i,
       ':limit' => $chunk,
     ])->fetchAll();
 

--- a/includes/tripal_alchemist.api.inc
+++ b/includes/tripal_alchemist.api.inc
@@ -520,7 +520,8 @@ function tripal_alchemist_delete_orphaned_entities($bundle_id) {
     // Get a chunk of orphaned entities
     $entities = db_query('SELECT entity_id FROM ' . $bundle_table . ' BT
                           LEFT JOIN chado.' . $chado_table . ' CT ON BT.record_id = CT.' . $primary_key . '
-                          WHERE CT.' . $primary_key . ' IS NULL ORDER BY entity_id desc
+                          WHERE CT.' . $primary_key . ' IS NULL 
+                          ORDER BY entity_id desc
                           LIMIT :limit', [
       ':limit' => $chunk,
     ])->fetchAll();

--- a/includes/tripal_alchemist.api.inc
+++ b/includes/tripal_alchemist.api.inc
@@ -501,10 +501,9 @@ function tripal_alchemist_delete_orphaned_entities($bundle_id) {
   $schema = chado_get_schema($chado_table);
   $primary_key = is_array($schema) ? $schema['primary key'][0] : NULL;
 
-  $count = (int) db_query('SELECT count(entity_id) FROM ' . $bundle_table . ' BT
-                  WHERE BT.record_id NOT IN (
-                          SELECT ' . $primary_key . ' FROM chado.' . $chado_table . '
-                )')->fetchField();
+  $count = (int) db_query('SELECT count(*) FROM ' . $bundle_table . ' BT
+                        LEFT JOIN chado.' . $chado_table . ' CT ON BT.record_id = CT.' . $primary_key . '
+                        WHERE CT.' . $primary_key . ' IS NULL')->fetchField();
 
   if ($count === 0) {
     print "Unable to find any orphaned entities.\n";
@@ -520,9 +519,8 @@ function tripal_alchemist_delete_orphaned_entities($bundle_id) {
   for ($i = 0; $i < $count; $i += $chunk) {
     // Get a chunk of orphaned entities
     $entities = db_query('SELECT entity_id FROM ' . $bundle_table . ' BT
-                  WHERE BT.record_id NOT IN (
-                          SELECT ' . $primary_key . ' FROM chado.' . $chado_table . '
-                ) ORDER BY entity_id desc
+                        LEFT JOIN chado.' . $chado_table . ' CT ON BT.record_id = CT.' . $primary_key . '
+                        WHERE CT.' . $primary_key . ' IS NULL ORDER BY entity_id desc
                   OFFSET :offset
                   LIMIT :limit', [
       ':offset' => $i,

--- a/includes/tripal_alchemist.api.inc
+++ b/includes/tripal_alchemist.api.inc
@@ -483,3 +483,77 @@ function tripal_alchemist_get_eligible_entities($collection, $source_bundle) {
 
   return $matching_entities;
 }
+
+/**
+ * Job callback to perform deletion of orphaned entities.
+ *
+ * @param int $bundle_id
+ *
+ * @throws \Exception
+ */
+function tripal_alchemist_delete_orphaned_entities($bundle_id) {
+  $bundle = db_query('SELECT bundle_id, data_table 
+             FROM chado_bundle CB WHERE bundle_id = :id',
+    [':id' => $bundle_id])->fetchObject();
+
+  $bundle_table = db_escape_table("chado_bio_data_{$bundle->bundle_id}");
+  $chado_table = db_escape_table($bundle->data_table);
+  $schema = chado_get_schema($chado_table);
+  $primary_key = is_array($schema) ? $schema['primary key'][0] : NULL;
+
+  $count = (int) db_query('SELECT count(entity_id) FROM ' . $bundle_table . ' BT
+                  WHERE BT.record_id NOT IN (
+                          SELECT ' . $primary_key . ' FROM chado.' . $chado_table . '
+                )')->fetchField();
+
+  if ($count === 0) {
+    print "Unable to find any orphaned entities.\n";
+    return;
+  }
+
+  print "Found $count orphaned entities.\n";
+
+  $chunk = 500;
+  $progress = 0;
+  print "Progress: {$progress}%; Memory: " . number_format(memory_get_usage()) . " bytes\r\033[K";
+
+  for ($i = 0; $i < $count; $i += $chunk) {
+    // Get a chunk of orphaned entities
+    $entities = db_query('SELECT entity_id FROM ' . $bundle_table . ' BT
+                  WHERE BT.record_id NOT IN (
+                          SELECT ' . $primary_key . ' FROM chado.' . $chado_table . '
+                ) ORDER BY entity_id desc
+                  OFFSET :offset
+                  LIMIT :limit', [
+      ':offset' => $i,
+      ':limit' => $chunk,
+    ])->fetchAll();
+
+    $ids = array_map(function ($entity) {
+      return (int) $entity->entity_id;
+    }, $entities);
+
+    if (empty($ids)) {
+      throw new Exception('Unable to find selected entities while attempting to delete orphaned entities.');
+    }
+
+    // This will trigger all needed hooks
+    /** @var \TripalEntityController $controller */
+    $controller = entity_get_controller('TripalEntity');
+    if ($controller->delete($ids) === FALSE) {
+      print "\nFailed to delete chunk {$i}/{$count}!\n";
+    }
+
+    // TODO: this is a temporary solution until the following issue is resolved
+    // TODO: https://github.com/tripal/tripal/issues/652
+    db_query('DELETE FROM chado_bio_data_' . $bundle_id . ' 
+              WHERE entity_id IN (:ids)', [':ids' => $ids]);
+
+    // Report progress
+    $progress = number_format(($i + $chunk) / $count * 100, 2);
+    print "Progress: {$progress}%; Memory: " . number_format(memory_get_usage()) . " bytes\r\033[K";
+  }
+
+  print "Progress: 100%; Memory: " . number_format(memory_get_usage()) . " bytes\n";
+  print "Done.\n";
+}

--- a/includes/tripal_alchemist.api.inc
+++ b/includes/tripal_alchemist.api.inc
@@ -519,10 +519,9 @@ function tripal_alchemist_delete_orphaned_entities($bundle_id) {
   for ($i = 0; $i < $count; $i += $chunk) {
     // Get a chunk of orphaned entities
     $entities = db_query('SELECT entity_id FROM ' . $bundle_table . ' BT
-                        LEFT JOIN chado.' . $chado_table . ' CT ON BT.record_id = CT.' . $primary_key . '
-                        WHERE CT.' . $primary_key . ' IS NULL ORDER BY entity_id desc
-                  OFFSET :offset
-                  LIMIT :limit', [
+                          LEFT JOIN chado.' . $chado_table . ' CT ON BT.record_id = CT.' . $primary_key . '
+                          WHERE CT.' . $primary_key . ' IS NULL ORDER BY entity_id desc
+                          LIMIT :limit', [
       ':offset' => $i,
       ':limit' => $chunk,
     ])->fetchAll();

--- a/includes/tripal_alchemist.unpublish_form.inc
+++ b/includes/tripal_alchemist.unpublish_form.inc
@@ -96,6 +96,8 @@ function tripal_alchemist_unpublish_form_submit($form, &$form_state) {
     'tripal_alchemist_delete_orphaned_entities', [$bundle_id], $user->uid, 10);
 
   drupal_set_message('Job submitted successfully!');
+  drupal_set_message('WARNING: It is expected to see a few tripal_chado errors
+   while the job is executing. The errors can be safely ignored.', 'warning');
 }
 
 /**

--- a/includes/tripal_alchemist.unpublish_form.inc
+++ b/includes/tripal_alchemist.unpublish_form.inc
@@ -32,6 +32,7 @@ function tripal_alchemist_unpublish_form($form, &$form_state) {
 
   $form['bundle_info_fieldset'] = [
     '#type' => 'fieldset',
+    '#title' => 'Search Results',
     '#states' => [
       'invisible' => [
         'select[name="bundles"]' => ['value' => ''],
@@ -48,10 +49,16 @@ function tripal_alchemist_unpublish_form($form, &$form_state) {
     $name = $bundles[$selected_bundle_id];
     $form['bundle_info_fieldset']['message'] = [
       '#type' => 'markup',
-      '#markup' => t('<p><strong>There are ' . $count . ' orphaned entities in the '.$name.' bundle.</strong></p>'),
+      '#markup' => t('<p><strong>There are ' . $count . ' orphaned entities in the ' . $name . ' bundle.</strong></p>'),
     ];
 
     if ($count > 0) {
+      $form['bundle_info_fieldset']['example_table'] = [
+        '#type' => 'markup',
+        '#prefix' => t('<p>The following is an example of the records that will get removed. This table contains a maximum of 10 records.</p>'),
+        '#markup' => tripal_alchemist_missing_records_table($selected_bundle_id),
+      ];
+
       $form['bundle_info_fieldset']['submit'] = [
         '#type' => 'submit',
         '#value' => 'Permanently Delete Orphaned Entities',
@@ -140,6 +147,49 @@ function tripal_alchemist_get_orphaned_counts_for_bundle($bundle_id) {
   return (int) $count;
 }
 
+/**
+ * Ajax callback for this form.
+ *
+ * @param array $form
+ *
+ * @return array
+ */
 function tripal_alchemist_unpublish_form_callback($form) {
   return $form['bundle_info_fieldset'];
+}
+
+function tripal_alchemist_missing_records_table($bundle_id) {
+  // Get the bundle
+  $bundle = db_query('SELECT bundle_id, data_table, label 
+             FROM chado_bundle CB
+             INNER JOIN tripal_bundle TB ON TB.id = CB.bundle_id
+             WHERE bundle_id = :id', [':id' => $bundle_id])->fetchObject();
+
+  $bundle_table = db_escape_table("chado_bio_data_{$bundle->bundle_id}");
+  $chado_table = db_escape_table($bundle->data_table);
+  $schema = chado_get_schema($chado_table);
+  $primary_key = is_array($schema) ? $schema['primary key'][0] : NULL;
+
+  $entities = db_query('SELECT TE.title, TE.id, BT.record_id FROM ' . $bundle_table . ' BT
+                        LEFT JOIN chado.' . $chado_table . ' CT ON BT.record_id = CT.' . $primary_key . '
+                        LEFT JOIN tripal_entity TE ON TE.id = BT.entity_id
+                        WHERE CT.' . $primary_key . ' IS NULL
+                        ORDER BY BT.entity_id ASC')->fetchAll();
+
+  return theme('table', [
+    'header' => [
+      'Entity ID',
+      'Title',
+      'Chado Table',
+      str_replace('_', ' ', $primary_key),
+    ],
+    'rows' => array_map(function ($entity) use ($chado_table) {
+      return [
+        $entity->id,
+        $entity->title,
+        $chado_table,
+        $entity->record_id,
+      ];
+    }, $entities),
+  ]);
 }

--- a/includes/tripal_alchemist.unpublish_form.inc
+++ b/includes/tripal_alchemist.unpublish_form.inc
@@ -23,7 +23,7 @@ function tripal_alchemist_unpublish_form($form, &$form_state) {
     '#type' => 'select',
     '#options' => $bundles,
     '#empty_option' => t('-- Select a Bundle --'),
-    '#description' => t('Bundles that have entities with no associated chado records are listed above.'),
+    '#description' => t('Select a bundle to check if it has orphaned entities.'),
     '#ajax' => [
       'callback' => 'tripal_alchemist_unpublish_form_callback',
       'wrapper' => 'bundle_info_fieldset_wrapper',

--- a/includes/tripal_alchemist.unpublish_form.inc
+++ b/includes/tripal_alchemist.unpublish_form.inc
@@ -187,7 +187,7 @@ function tripal_alchemist_missing_records_table($bundle_id) {
     'rows' => array_map(function ($entity) use ($chado_table) {
       return [
         $entity->id,
-        $entity->title,
+        l($entity->title, 'bio_data/'.$entity->id),
         $chado_table,
         $entity->record_id,
       ];

--- a/includes/tripal_alchemist.unpublish_form.inc
+++ b/includes/tripal_alchemist.unpublish_form.inc
@@ -18,22 +18,40 @@ function tripal_alchemist_unpublish_form($form, &$form_state) {
     return $form;
   }
 
-  // Merge the arrays
-  $bundles = [
-    'select' => '-- Select a Bundle --'
-  ] + $bundles;
-
   $form['bundles'] = [
     '#title' => t('Select a bundle'),
     '#type' => 'select',
     '#options' => $bundles,
+    '#empty_option' => t('-- Select a Bundle --'),
     '#description' => t('Bundles that have entities with no associated chado records are listed above.'),
+    '#ajax' => [
+      'callback' => 'tripal_alchemist_unpublish_form_callback',
+      'wrapper' => 'bundle_info_fieldset_wrapper',
+    ],
   ];
 
-  $form['submit'] = [
-    '#type' => 'submit',
-    '#value' => 'Permanently Delete Orphaned Entities',
+  $form['bundle_info_fieldset'] = [
+    '#type' => 'fieldset',
+    '#collapsible' => FALSE,
+    '#prefix' => '<div id="bundle_info_fieldset_wrapper">',
+    '#suffix' => '</div>',
   ];
+
+  $selected_bundle_id = isset($form_state['values']['bundles']) ? $form_state['values']['bundles'] : NULL;
+  if ($selected_bundle_id) {
+    $count = tripal_alchemist_get_orphaned_counts_for_bundle($selected_bundle_id);
+    $form['bundle_info_fieldset']['message'] = [
+      '#type' => 'markup',
+      '#markup' => t('<p><strong>There are ' . $count . ' orphaned entities in this bundle.</strong></p>'),
+    ];
+
+    if ($count > 0) {
+      $form['bundle_info_fieldset']['submit'] = [
+        '#type' => 'submit',
+        '#value' => 'Permanently Delete Orphaned Entities',
+      ];
+    }
+  }
 
   return $form;
 }
@@ -77,32 +95,36 @@ function tripal_alchemist_get_orphaned_bundles() {
              FROM chado_bundle CB
              INNER JOIN tripal_bundle TB ON TB.id = CB.bundle_id')->fetchAll();
 
-  $counts = [];
+  $mapped = [];
 
   foreach ($bundles as $bundle) {
-    $count = tripal_alchemist_get_orphaned_counts_for_bundle($bundle);
-    if ($count > 0) {
-      $counts[$bundle->bundle_id] = "{$bundle->label} has {$count} orphaned entities.";
-    }
+    $mapped[$bundle->bundle_id] = "{$bundle->label}";
   }
 
-  return $counts;
+  return $mapped;
 }
 
 /**
  * Get the count of orphaned entities per bundle.
  *
- * @param $bundle
+ * @param int $bundle
  *
  * @return int
  */
-function tripal_alchemist_get_orphaned_counts_for_bundle($bundle) {
+function tripal_alchemist_get_orphaned_counts_for_bundle($bundle_id) {
+  // Get the bundle
+  $bundle = db_query('SELECT bundle_id, data_table, label 
+             FROM chado_bundle CB
+             INNER JOIN tripal_bundle TB ON TB.id = CB.bundle_id
+             WHERE bundle_id = :id', [':id' => $bundle_id])->fetchObject();
+
   $bundle_table = db_escape_table("chado_bio_data_{$bundle->bundle_id}");
   $chado_table = db_escape_table($bundle->data_table);
   $schema = chado_get_schema($chado_table);
   $primary_key = is_array($schema) ? $schema['primary key'][0] : NULL;
   $count = 0;
 
+  // Get the count
   if ($primary_key) {
     $count = db_query('SELECT count(*) FROM ' . $bundle_table . ' BT
                         WHERE BT.record_id NOT IN (
@@ -111,4 +133,8 @@ function tripal_alchemist_get_orphaned_counts_for_bundle($bundle) {
   }
 
   return (int) $count;
+}
+
+function tripal_alchemist_unpublish_form_callback($form) {
+  return $form['bundle_info_fieldset'];
 }

--- a/includes/tripal_alchemist.unpublish_form.inc
+++ b/includes/tripal_alchemist.unpublish_form.inc
@@ -174,7 +174,8 @@ function tripal_alchemist_missing_records_table($bundle_id) {
                         LEFT JOIN chado.' . $chado_table . ' CT ON BT.record_id = CT.' . $primary_key . '
                         LEFT JOIN tripal_entity TE ON TE.id = BT.entity_id
                         WHERE CT.' . $primary_key . ' IS NULL
-                        ORDER BY BT.entity_id ASC')->fetchAll();
+                        ORDER BY BT.entity_id ASC
+                        LIMIT 10')->fetchAll();
 
   return theme('table', [
     'header' => [

--- a/includes/tripal_alchemist.unpublish_form.inc
+++ b/includes/tripal_alchemist.unpublish_form.inc
@@ -32,6 +32,11 @@ function tripal_alchemist_unpublish_form($form, &$form_state) {
 
   $form['bundle_info_fieldset'] = [
     '#type' => 'fieldset',
+    '#states' => [
+      'invisible' => [
+        'select[name="bundles"]' => ['value' => ''],
+      ],
+    ],
     '#collapsible' => FALSE,
     '#prefix' => '<div id="bundle_info_fieldset_wrapper">',
     '#suffix' => '</div>',
@@ -40,9 +45,10 @@ function tripal_alchemist_unpublish_form($form, &$form_state) {
   $selected_bundle_id = isset($form_state['values']['bundles']) ? $form_state['values']['bundles'] : NULL;
   if ($selected_bundle_id) {
     $count = tripal_alchemist_get_orphaned_counts_for_bundle($selected_bundle_id);
+    $name = $bundles[$selected_bundle_id];
     $form['bundle_info_fieldset']['message'] = [
       '#type' => 'markup',
-      '#markup' => t('<p><strong>There are ' . $count . ' orphaned entities in this bundle.</strong></p>'),
+      '#markup' => t('<p><strong>There are ' . $count . ' orphaned entities in the '.$name.' bundle.</strong></p>'),
     ];
 
     if ($count > 0) {
@@ -127,8 +133,8 @@ function tripal_alchemist_get_orphaned_counts_for_bundle($bundle_id) {
   // Get the count
   if ($primary_key) {
     $count = db_query('SELECT count(*) FROM ' . $bundle_table . ' BT
-                        LEFT JOIN chado.'.$chado_table.' CT ON BT.record_id = CT.'.$primary_key.'
-                        WHERE CT.'.$primary_key.' IS NULL')->fetchField();
+                        LEFT JOIN chado.' . $chado_table . ' CT ON BT.record_id = CT.' . $primary_key . '
+                        WHERE CT.' . $primary_key . ' IS NULL')->fetchField();
   }
 
   return (int) $count;

--- a/includes/tripal_alchemist.unpublish_form.inc
+++ b/includes/tripal_alchemist.unpublish_form.inc
@@ -127,9 +127,8 @@ function tripal_alchemist_get_orphaned_counts_for_bundle($bundle_id) {
   // Get the count
   if ($primary_key) {
     $count = db_query('SELECT count(*) FROM ' . $bundle_table . ' BT
-                        WHERE BT.record_id NOT IN (
-                          SELECT ' . $primary_key . ' FROM chado.' . $chado_table . '
-                        )')->fetchField();
+                        LEFT JOIN chado.'.$chado_table.' CT ON BT.record_id = CT.'.$primary_key.'
+                        WHERE CT.'.$primary_key.' IS NULL')->fetchField();
   }
 
   return (int) $count;

--- a/includes/tripal_alchemist.unpublish_form.inc
+++ b/includes/tripal_alchemist.unpublish_form.inc
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Unpublish orphaned entities form.
+ *
+ * @param $form
+ * @param $form_state
+ */
+function tripal_alchemist_unpublish_form($form, &$form_state) {
+  $bundles = tripal_alchemist_get_orphaned_bundles();
+
+  if (empty($bundles)) {
+    $form['message'] = [
+      '#type' => 'markup',
+      '#markup' => t("<p>No orphaned entities detected.</p>"),
+    ];
+
+    return $form;
+  }
+
+  // Merge the arrays
+  $bundles = [
+    'select' => '-- Select a Bundle --'
+  ] + $bundles;
+
+  $form['bundles'] = [
+    '#title' => t('Select a bundle'),
+    '#type' => 'select',
+    '#options' => $bundles,
+    '#description' => t('Bundles that have entities with no associated chado records are listed above.'),
+  ];
+
+  $form['submit'] = [
+    '#type' => 'submit',
+    '#value' => 'Permanently Delete Orphaned Entities',
+  ];
+
+  return $form;
+}
+
+/**
+ * Validate form entries.
+ *
+ * @param array $form
+ * @param array $form_state
+ */
+function tripal_alchemist_unpublish_form_validate($form, &$form_state) {
+  $bundle_id = isset($form_state['values']['bundles']) ? $form_state['values']['bundles'] : NULL;
+
+  if (empty($bundle_id) || !is_numeric($bundle_id)) {
+    form_set_error('bundles', t('Please select a valid bundle.'));
+  }
+}
+
+/**
+ * Process unpublish form.
+ *
+ * @param array $form
+ * @param array $form_state
+ */
+function tripal_alchemist_unpublish_form_submit($form, &$form_state) {
+  global $user;
+  $bundle_id = isset($form_state['values']['bundles']) ? $form_state['values']['bundles'] : NULL;
+  tripal_add_job('Delete Orphaned Entities', 'tripal_alchemist',
+    'tripal_alchemist_delete_orphaned_entities', [$bundle_id], $user->uid, 10);
+
+  drupal_set_message('Job submitted successfully!');
+}
+
+/**
+ * Get bundles that have orphaned entities.
+ *
+ * @return array
+ */
+function tripal_alchemist_get_orphaned_bundles() {
+  $bundles = db_query('SELECT bundle_id, data_table, label 
+             FROM chado_bundle CB
+             INNER JOIN tripal_bundle TB ON TB.id = CB.bundle_id')->fetchAll();
+
+  $counts = [];
+
+  foreach ($bundles as $bundle) {
+    $count = tripal_alchemist_get_orphaned_counts_for_bundle($bundle);
+    if ($count > 0) {
+      $counts[$bundle->bundle_id] = "{$bundle->label} has {$count} orphaned entities.";
+    }
+  }
+
+  return $counts;
+}
+
+/**
+ * Get the count of orphaned entities per bundle.
+ *
+ * @param $bundle
+ *
+ * @return int
+ */
+function tripal_alchemist_get_orphaned_counts_for_bundle($bundle) {
+  $bundle_table = db_escape_table("chado_bio_data_{$bundle->bundle_id}");
+  $chado_table = db_escape_table($bundle->data_table);
+  $schema = chado_get_schema($chado_table);
+  $primary_key = is_array($schema) ? $schema['primary key'][0] : NULL;
+  $count = 0;
+
+  if ($primary_key) {
+    $count = db_query('SELECT count(*) FROM ' . $bundle_table . ' BT
+                        WHERE BT.record_id NOT IN (
+                          SELECT ' . $primary_key . ' FROM chado.' . $chado_table . '
+                        )')->fetchField();
+  }
+
+  return (int) $count;
+}

--- a/tripal_alchemist.module
+++ b/tripal_alchemist.module
@@ -1,6 +1,6 @@
 <?php
 
-include_once('includes/tripal_alchemist.api.inc');
+require_once 'includes/tripal_alchemist.api.inc';
 
 /**
  * implement hook menu
@@ -11,21 +11,28 @@ function tripal_alchemist_menu() {
 
   $items[$admin_url_base] = [
     'title' => 'Tripal Alchemist',
-    'description' => t('Tripal Alchemist: Convert Tripal 3 Entities'),
-    'access arguments' => [' tripal alchemist'],
+    'description' => t('Tripal Alchemist: Manage Tripal 3 Entities'),
+    'access arguments' => ['tripal alchemist'],
+    'page callback' => 'tripal_alchemist_admin_index_page',
+  ];
+
+  $items[$admin_url_base . '/converter_form'] = [
+    'title' => 'Convert Entity Types',
+    'description' => t('Convert Tripal 3 Entities'),
+    'access arguments' => ['administer tripal'],
     'page callback' => 'drupal_get_form',
     'page arguments' => ['tripal_alchemist_converter_form'],
     'file' => 'includes/tripal_alchemist_converter.form.inc',
     'file_path' => drupal_get_path('module', 'tripal_alchemist'),
   ];
 
-  $items[$admin_url_base . "/entity_converter"] = [
-    'title' => 'Tripal Alchemist',
-    'description' => t('Tripal Alchemist: Convert Tripal 3 Entities'),
-    'access arguments' => [' tripal alchemist'],
+  $items[$admin_url_base . "/unpublish_form"] = [
+    'title' => 'Delete Orphaned Entities',
+    'description' => t('Unpublish entities that have no associated records in their corresponding chado tables'),
+    'access arguments' => ['administer tripal'],
     'page callback' => 'drupal_get_form',
-    'page arguments' => ['tripal_alchemist_converter_form'],
-    'file' => 'includes/tripal_alchemist_converter.form.inc',
+    'page arguments' => ['tripal_alchemist_unpublish_form'],
+    'file' => 'includes/tripal_alchemist.unpublish_form.inc',
     'file_path' => drupal_get_path('module', 'tripal_alchemist'),
   ];
 
@@ -43,4 +50,30 @@ function tripal_alchemist_cron_queue_info() {
   ];
 
   return $queues;
+}
+
+/**
+ * Tripal Alchemist admin index page.
+ *
+ * Lists all links in the main menu.
+ *
+ * @return string
+ */
+function tripal_alchemist_admin_index_page() {
+  $items = tripal_alchemist_menu();
+
+  // Exclude the first page
+  $admin_url_base = 'admin/tripal/extension/tripal_alchemist';
+  unset($items[$admin_url_base]);
+
+  $list = '';
+  foreach ($items as $url => $item) {
+    $list .= '<p><strong>';
+    $list .= l($item['title'] ?: 'missing title', $url);
+    $list .= '</strong></p>';
+    $list .= '<p>' . $item['description'] ?: '' . '</p>';
+    $list .= '<hr>';
+  }
+
+  return $list;
 }


### PR DESCRIPTION
This PR adds a form to allow for the deletion of entities that are missing chado records. This acts as an `unpublish` method for cases when the chado record is deleted but the entity didn't get deleted.

### Testing

The form is super simple. Single element with a list of bundles that have orphaned entities. Select the bundle and hit submit then run the job. The entities will get delete and hooks for the deletion will get triggered. This job may take a while to complete depending on the number of orphaned entities.

To set up a scenario where you can test this on a dev site:
1. Create an organism using the GUI
1. Delete the organism from chado.organism
1. Visit the new form page and see that there is 1 orphaned organism entity